### PR TITLE
Create CNAME

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+civcraft.co


### PR DESCRIPTION
Setup a CNAME file so when you go to civcraft.co it doesn't redirect to https://civcraft.github.io/civcraftsite/

After you merge this pull request setup two A records for the domain apex (civcraft.co) that point to "192.30.252.153" and "192.30.252.154" in your DNS settings.

I would also suggest looking into SRV records so civcraft.co can point to the minecraft server and the github pages site at the same time.
